### PR TITLE
Put team name instead of team id, because when showing request of spe…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.2.RELEASE</version>
+    <version>2.0.6.RELEASE</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 

--- a/src/main/java/eu/execom/hawaii/dto/UserDto.java
+++ b/src/main/java/eu/execom/hawaii/dto/UserDto.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 public class UserDto {
 
   private Long id;
-  private Long teamId;
+  private String teamName;
   private Long leaveProfileId;
   private String fullName;
   private String email;
@@ -24,7 +24,7 @@ public class UserDto {
 
   public UserDto(User user) {
     this.id = user.getId();
-    this.teamId = (user.getTeam().getId());
+    this.teamName = (user.getTeam().getName());
     this.leaveProfileId = (user.getLeaveProfile().getId());
     this.fullName = user.getFullName();
     this.email = user.getEmail();


### PR DESCRIPTION
Put team name instead of team id in UserDto, because when showing request of specific user it should display the team name to which user belongs, not team id.