### PR TITLE
Redirected all api calls to /api. Using id_token instead of access_token

### DIFF
--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -41,5 +41,5 @@
     "prettier": "^1.13.3",
     "react-scripts": "1.1.4"
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "http://localhost:8080/api"
 }

--- a/src/main/frontend/src/store/sagas/getTokenSaga.js
+++ b/src/main/frontend/src/store/sagas/getTokenSaga.js
@@ -8,7 +8,7 @@ import { tokenRequest } from '../services/getTokenRequest';
 
 export const getToken = function*(action) {
   try {
-    const responseGoogle = yield call(tokenRequest, action.payload.accessToken);
+    const responseGoogle = yield call(tokenRequest, action.payload);
     yield put(receiveToken(responseGoogle));
   } catch (error) {
     yield put(receiveTokenError(error));

--- a/src/main/frontend/src/store/services/getTokenRequest.js
+++ b/src/main/frontend/src/store/services/getTokenRequest.js
@@ -1,10 +1,10 @@
 import request from 'superagent';
 
-export const tokenRequest = async accessToken => {
+export const tokenRequest = async userObj => {
   try {
     const response = await request
-      .get('/signin')
-      .set('Authorization', accessToken)
+      .get(`/users/${userObj.profileObj.email}`)
+      .set('X-ID-TOKEN', userObj.tokenId)
       .set('Accept', 'application/json');
 
     const [token, role, user] = [
@@ -13,9 +13,10 @@ export const tokenRequest = async accessToken => {
       response.body
     ];
 
-    sessionStorage.setItem('token', token);
-    sessionStorage.setItem('role', role);
-    sessionStorage.setItem('user', user);
+    // TODO vrackovic: Investigate `user` stored in sessionStorage and store it if needed in future
+    sessionStorage.setItem('token', userObj.tokenId);
+    sessionStorage.setItem('role', response.body.userRole);
+    // sessionStorage.setItem('user', user);
     return {
       token,
       role,


### PR DESCRIPTION
- Changed `GetTokenRequest` to initially send `id_token` instead of `access_token`
- Currently using `/users/{email}`to load users data. Probably would be changed to `/me` after first `id_token` validation to gather data about logged in user
- Previous `http://localhost:8080` proxy changed to `http://localhost:8080/api` as requested from changes on backend
- `getTokenSaga` passes whole user object received from google instead of only `access_token`